### PR TITLE
Add dynamic Einstein hat background

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [Automatic RSS feed](https://docs.astro.build/en/guides/rss)
 - Auto-generated [sitemap](https://docs.astro.build/en/guides/integrations-guide/sitemap/)
 - [Expressive Code](https://expressive-code.com/) source code and syntax highlighter
-- Dynamic Einstein hat background that adapts to light and dark theme
+- Dynamic Einstein hat background (from jmaccs/the-hat) that adapts to light and dark theme
 
 ## Credits
 
@@ -77,9 +77,11 @@ To add images in blog articles, insert a folder in the `src/content/` directory,
 
 To change the theme colours of the site, edit the `src/styles/app.css` file.
 
-The site background is generated from the Einstein hat monotile at runtime.
-Colors follow the current theme, so switching between light and dark mode will
-redraw the pattern accordingly. You can modify the drawing logic in
+The site background is generated from the Einstein hat monotile at runtime using
+the [p5.js](https://p5js.org/) library. Geometry utilities and the hat outline
+come directly from [jmaccs/the-hat](https://github.com/jmaccs/the-hat). Colors
+follow the current theme, so switching between light and dark mode will redraw
+the pattern accordingly. You can modify the drawing logic in
 `public/hatBackground.js` to customise the colours or tile layout.
 
 To change the fonts of the site, add your font files into `/public`, add it as a `@font-face` in the `src/styles/app.css` file, as a `fontFamily` in the `tailwind.config.js` file, and apply the new font class to the `body` tag in the `src/layouts/BaseLayout.astro` file.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Automatic RSS feed](https://docs.astro.build/en/guides/rss)
 - Auto-generated [sitemap](https://docs.astro.build/en/guides/integrations-guide/sitemap/)
 - [Expressive Code](https://expressive-code.com/) source code and syntax highlighter
+- Dynamic Einstein hat background that adapts to light and dark theme
 
 ## Credits
 
@@ -75,5 +76,10 @@ To add images in blog articles, insert a folder in the `src/content/` directory,
 ## Theming
 
 To change the theme colours of the site, edit the `src/styles/app.css` file.
+
+The site background is generated from the Einstein hat monotile at runtime.
+Colors follow the current theme, so switching between light and dark mode will
+redraw the pattern accordingly. You can modify the drawing logic in
+`public/hatBackground.js` to customise the colours or tile layout.
 
 To change the fonts of the site, add your font files into `/public`, add it as a `@font-face` in the `src/styles/app.css` file, as a `fontFamily` in the `tailwind.config.js` file, and apply the new font class to the `body` tag in the `src/layouts/BaseLayout.astro` file.

--- a/public/geometry.js
+++ b/public/geometry.js
@@ -1,0 +1,96 @@
+const r3 = 1.7320508075688772;
+const hr3 = 0.8660254037844386;
+const ident = [1, 0, 0, 0, 1, 0];
+
+function pt( x, y )
+{
+	return { x : x, y : y };
+}
+
+function hexPt( x, y )
+{
+	return pt( x + 0.5*y, hr3*y );
+}
+
+// Affine matrix inverse
+function inv( T ) {
+	const det = T[0]*T[4] - T[1]*T[3];
+	return [T[4]/det, -T[1]/det, (T[1]*T[5]-T[2]*T[4])/det,
+		-T[3]/det, T[0]/det, (T[2]*T[3]-T[0]*T[5])/det];
+};
+
+// Affine matrix multiply
+function mul( A, B )
+{
+	return [A[0]*B[0] + A[1]*B[3], 
+		A[0]*B[1] + A[1]*B[4],
+		A[0]*B[2] + A[1]*B[5] + A[2],
+
+		A[3]*B[0] + A[4]*B[3], 
+		A[3]*B[1] + A[4]*B[4],
+		A[3]*B[2] + A[4]*B[5] + A[5]];
+}
+
+function padd( p, q )
+{
+	return { x : p.x + q.x, y : p.y + q.y };
+}
+
+function psub( p, q )
+{
+	return { x : p.x - q.x, y : p.y - q.y };
+}
+
+// Rotation matrix
+function trot( ang )
+{
+	const c = cos( ang );
+	const s = sin( ang );
+	return [c, -s, 0, s, c, 0];
+}
+
+// Translation matrix
+function ttrans( tx, ty )
+{
+	return [1, 0, tx, 0, 1, ty];
+}
+
+function rotAbout( p, ang )
+{
+	return mul( ttrans( p.x, p.y ), 
+		mul( trot( ang ), ttrans( -p.x, -p.y ) ) );
+}
+
+// Matrix * point
+function transPt( M, P )
+{
+	return pt(M[0]*P.x + M[1]*P.y + M[2], M[3]*P.x + M[4]*P.y + M[5]);
+}
+
+// Match unit interval to line segment p->q
+function matchSeg( p, q )
+{
+	return [q.x-p.x, p.y-q.y, p.x,  q.y-p.y, q.x-p.x, p.y];
+};
+
+// Match line segment p1->q1 to line segment p2->q2
+function matchTwo( p1, q1, p2, q2 )
+{
+	return mul( matchSeg( p2, q2 ), inv( matchSeg( p1, q1 ) ) );
+};
+
+// Intersect two lines defined by segments p1->q1 and p2->q2
+function intersect( p1, q1, p2, q2 )
+{
+    const d = (q2.y - p2.y) * (q1.x - p1.x) - (q2.x - p2.x) * (q1.y - p1.y);
+    const uA = ((q2.x - p2.x) * (p1.y - p2.y) - (q2.y - p2.y) * (p1.x - p2.x)) / d;
+    // const uB = ((q1.x - p1.x) * (p1.y - p2.y) - (q1.y - p1.y) * (p1.x - p2.x)) / d;
+
+    return pt( p1.x + uA * (q1.x - p1.x), p1.y + uA * (q1.y - p1.y) );
+}
+
+const hat_outline = [
+    hexPt(0, 0), hexPt(-1,-1), hexPt(0,-2), hexPt(2,-2),
+    hexPt(2,-1), hexPt(4,-2), hexPt(5,-1), hexPt(4, 0),
+    hexPt(3, 0), hexPt(2, 2), hexPt(0, 3), hexPt(0, 2),
+    hexPt(-1, 2) ];

--- a/public/hatBackground.js
+++ b/public/hatBackground.js
@@ -1,0 +1,69 @@
+;(() => {
+	const hr3 = 0.8660254037844386
+	const outline = [
+		[0, 0],
+		[-1.5, -hr3],
+		[-1.0, -2 * hr3],
+		[1.0, -2 * hr3],
+		[1.5, -hr3],
+		[3.0, -2 * hr3],
+		[4.5, -hr3],
+		[4.0, 0],
+		[3.0, 0],
+		[3.0, 2 * hr3],
+		[1.5, 3 * hr3],
+		[1.0, 2 * hr3],
+		[0.0, 2 * hr3]
+	]
+	const canvas = document.createElement('canvas')
+	canvas.style.position = 'fixed'
+	canvas.style.top = '0'
+	canvas.style.left = '0'
+	canvas.style.width = '100%'
+	canvas.style.height = '100%'
+	canvas.style.zIndex = '-1'
+	canvas.style.pointerEvents = 'none'
+	document.body.prepend(canvas)
+	const ctx = canvas.getContext('2d')
+	function getColor(name) {
+		const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+		return `hsl(${val})`
+	}
+	function resize() {
+		canvas.width = window.innerWidth
+		canvas.height = window.innerHeight
+	}
+	function drawHat(x, y, s, rot = 0) {
+		ctx.save()
+		ctx.translate(x, y)
+		ctx.rotate(rot)
+		ctx.beginPath()
+		ctx.moveTo(outline[0][0] * s, outline[0][1] * s)
+		for (let i = 1; i < outline.length; i++) {
+			ctx.lineTo(outline[i][0] * s, outline[i][1] * s)
+		}
+		ctx.closePath()
+		ctx.fill()
+		ctx.stroke()
+		ctx.restore()
+	}
+	function draw() {
+		resize()
+		ctx.clearRect(0, 0, canvas.width, canvas.height)
+		ctx.fillStyle = getColor('--accent')
+		ctx.strokeStyle = getColor('--foreground')
+		ctx.lineWidth = 1
+		const scale = 40
+		const tileW = 6 * scale
+		const tileH = 4.33 * scale
+		for (let y = -tileH; y < canvas.height + tileH; y += tileH) {
+			for (let x = -tileW; x < canvas.width + tileW; x += tileW) {
+				drawHat(x, y, scale)
+				drawHat(x + tileW / 2, y + tileH / 2, scale, Math.PI)
+			}
+		}
+	}
+	draw()
+	window.addEventListener('resize', draw)
+	document.addEventListener('theme-change', draw)
+})()

--- a/public/hatBackground.js
+++ b/public/hatBackground.js
@@ -1,69 +1,52 @@
-;(() => {
-	const hr3 = 0.8660254037844386
-	const outline = [
-		[0, 0],
-		[-1.5, -hr3],
-		[-1.0, -2 * hr3],
-		[1.0, -2 * hr3],
-		[1.5, -hr3],
-		[3.0, -2 * hr3],
-		[4.5, -hr3],
-		[4.0, 0],
-		[3.0, 0],
-		[3.0, 2 * hr3],
-		[1.5, 3 * hr3],
-		[1.0, 2 * hr3],
-		[0.0, 2 * hr3]
-	]
-	const canvas = document.createElement('canvas')
-	canvas.style.position = 'fixed'
-	canvas.style.top = '0'
-	canvas.style.left = '0'
-	canvas.style.width = '100%'
-	canvas.style.height = '100%'
-	canvas.style.zIndex = '-1'
-	canvas.style.pointerEvents = 'none'
-	document.body.prepend(canvas)
-	const ctx = canvas.getContext('2d')
-	function getColor(name) {
-		const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
-		return `hsl(${val})`
-	}
-	function resize() {
-		canvas.width = window.innerWidth
-		canvas.height = window.innerHeight
-	}
-	function drawHat(x, y, s, rot = 0) {
-		ctx.save()
-		ctx.translate(x, y)
-		ctx.rotate(rot)
-		ctx.beginPath()
-		ctx.moveTo(outline[0][0] * s, outline[0][1] * s)
-		for (let i = 1; i < outline.length; i++) {
-			ctx.lineTo(outline[i][0] * s, outline[i][1] * s)
-		}
-		ctx.closePath()
-		ctx.fill()
-		ctx.stroke()
-		ctx.restore()
-	}
-	function draw() {
-		resize()
-		ctx.clearRect(0, 0, canvas.width, canvas.height)
-		ctx.fillStyle = getColor('--accent')
-		ctx.strokeStyle = getColor('--foreground')
-		ctx.lineWidth = 1
-		const scale = 40
-		const tileW = 6 * scale
-		const tileH = 4.33 * scale
-		for (let y = -tileH; y < canvas.height + tileH; y += tileH) {
-			for (let x = -tileW; x < canvas.width + tileW; x += tileW) {
-				drawHat(x, y, scale)
-				drawHat(x + tileW / 2, y + tileH / 2, scale, Math.PI)
-			}
-		}
-	}
-	draw()
-	window.addEventListener('resize', draw)
-	document.addEventListener('theme-change', draw)
-})()
+(function () {
+  function getColor(name, p) {
+    const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return p.color(`hsl(${val})`);
+  }
+
+  const sketch = (p) => {
+    p.setup = function () {
+      p.createCanvas(window.innerWidth, window.innerHeight);
+      p.noLoop();
+      window.addEventListener('resize', () => {
+        p.resizeCanvas(window.innerWidth, window.innerHeight);
+        drawPattern();
+      });
+      document.addEventListener('theme-change', drawPattern);
+      drawPattern();
+    };
+
+    function drawPattern() {
+      p.clear();
+      const fillCol = getColor('--accent', p);
+      const strokeCol = getColor('--foreground', p);
+      p.fill(fillCol);
+      p.stroke(strokeCol);
+      p.strokeWeight(1);
+
+      const scale = 40;
+      const tileW = 6 * scale;
+      const tileH = 4 * hr3 * scale;
+      for (let y = -tileH; y < p.height + tileH; y += tileH) {
+        for (let x = -tileW; x < p.width + tileW; x += tileW) {
+          drawHat(x, y, scale, 0);
+          drawHat(x + tileW / 2, y + tileH / 2, scale, Math.PI);
+        }
+      }
+    }
+
+    function drawHat(x, y, s, rot) {
+      p.push();
+      p.translate(x, y);
+      p.rotate(rot);
+      p.beginShape();
+      for (const pt of hat_outline) {
+        p.vertex(pt.x * s, pt.y * s);
+      }
+      p.endShape(p.CLOSE);
+      p.pop();
+    }
+  };
+
+  new p5(sketch);
+})();

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,6 +24,7 @@ const {
 
 	<body class='flex justify-center bg-background'>
 		<ThemeProvider />
+		<script src='/hatBackground.js' defer></script>
 		<main
 			class='flex min-h-screen w-screen max-w-[60rem] flex-col items-center px-6 pb-10 pt-7 font-satoshi text-[0.92rem] leading-relaxed sm:px-10 lg:px-10'
 		>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,10 +22,12 @@ const {
 		<BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
 	</head>
 
-	<body class='flex justify-center bg-background'>
-		<ThemeProvider />
-		<script src='/hatBackground.js' defer></script>
-		<main
+        <body class='flex justify-center bg-background'>
+                <ThemeProvider />
+                <script src='https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.6.0/p5.min.js'></script>
+                <script src='/geometry.js'></script>
+                <script src='/hatBackground.js' defer></script>
+                <main
 			class='flex min-h-screen w-screen max-w-[60rem] flex-col items-center px-6 pb-10 pt-7 font-satoshi text-[0.92rem] leading-relaxed sm:px-10 lg:px-10'
 		>
 			<Header />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -66,7 +66,7 @@
 	* {
 		@apply border-border;
 	}
-	body {
-		@apply bg-background text-foreground;
-	}
+       body {
+               @apply bg-background text-foreground;
+       }
 }


### PR DESCRIPTION
## Summary
- dynamically render hat background that adapts to theme
- remove static PNG background
- document dynamic background usage in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68557a5721f883208c729bd73e100daf